### PR TITLE
Upgrade feign client version to 13.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
         <json.simple.version>1.1</json.simple.version>
         <gson.version>2.1</gson.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
-        <feign.version>11.0</feign.version>
+        <feign.version>13.2.1</feign.version>
         <maven.spotbugsplugin.version>3.1.10</maven.spotbugsplugin.version>
         <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
         <version.checkstyle>8.34</version.checkstyle>


### PR DESCRIPTION
## Purpose
We need to $subject to resolve the error encountered during server startup when using PingFederate as a third-party Key Manager in APIM 

Resolves: https://github.com/wso2/api-manager/issues/4567

## Approach
Upgraded the feign client version in the pom file.

Tested with the new `pingfederate.key.manager` jar. The KM is created as intended, without the above error log.


